### PR TITLE
Allow WORD_TERM regex match to execute before Func

### DIFF
--- a/sanitizer.js
+++ b/sanitizer.js
@@ -920,6 +920,10 @@ var decodeCss;
   // ident  ::=  '-'? nmstart nmchar*
   var IDENT = '-?' + NMSTART + NMCHAR + '*';
 
+  //Positive lookahead for functions in order to safeguard against catastrophic backtracking
+  //When an opening brace is not present
+  var FUNCTION_IDENT = '-?(?=(' + NMSTART + NMCHAR + '+))\\1';
+
   // ATKEYWORD  ::=  '@' ident
   var ATKEYWORD = '@' + IDENT;
   // HASH  ::=  '#' name
@@ -951,7 +955,8 @@ var decodeCss;
   // FUNCTION  ::=  ident '('
   // Diff: We exclude url explicitly.
   // TODO: should we be tolerant of "fn ("?
-  var FUNCTION = '(?!url[(])' + IDENT + '[(]';
+  var FUNCTION = '(?!url[(])' + FUNCTION_IDENT + '[(]';
+
   // INCLUDES  ::=  "~="
   var INCLUDES = '~=';
   // DASHMATCH  ::=  "|="
@@ -972,7 +977,7 @@ var decodeCss;
   var BOM = '\\uFEFF';
 
   var CSS_TOKEN = new RegExp([
-      BOM, UNICODE_RANGE, URI, WORD_TERM, FUNCTION, STRING, NUMERIC_VALUE,
+      BOM, UNICODE_RANGE, URI, FUNCTION, WORD_TERM, STRING, NUMERIC_VALUE,
       CDO, CDC, S, COMMENT, CMP_OPS, CHAR].join("|"), 'gi');
 
   var CSS_DECODER = new RegExp('\\\\(?:' + ESCAPE_TAIL + '|' + NL + ')', 'g');
@@ -996,6 +1001,7 @@ var decodeCss;
     cssText = '' + cssText;
     var tokens = cssText.replace(/\r\n?/g, '\n')  // Normalize CRLF & CR to LF.
         .match(CSS_TOKEN) || [];
+
     var j = 0;
     var last = ' ';
     for (var i = 0, n = tokens.length; i < n; ++i) {

--- a/sanitizer.js
+++ b/sanitizer.js
@@ -972,7 +972,7 @@ var decodeCss;
   var BOM = '\\uFEFF';
 
   var CSS_TOKEN = new RegExp([
-      BOM, UNICODE_RANGE, URI, FUNCTION, WORD_TERM, STRING, NUMERIC_VALUE,
+      BOM, UNICODE_RANGE, URI, WORD_TERM, FUNCTION, STRING, NUMERIC_VALUE,
       CDO, CDC, S, COMMENT, CMP_OPS, CHAR].join("|"), 'gi');
 
   var CSS_DECODER = new RegExp('\\\\(?:' + ESCAPE_TAIL + '|' + NL + ')', 'g');

--- a/test/css.js
+++ b/test/css.js
@@ -45,3 +45,10 @@ test('inline styles are ok', function (t) {
   t.equal(result, string);
   t.end();
 });
+// This test should time out if there's a regression in the regex that will cause catastrophic backtracking when evaluating a doubly escaped string
+test('Should sanitize doubly escaped nonsense values', function(t) {
+    var string = '<span style="font-size: 10.5pt ; font-family: \\00E5\\00BE\\00AE\\00E8\\00BB\\0178\\00E6\\00AD\\00A3\\00E9\\00BB\\2018\\00E9\\00AB\\201D ; color: black"></span>';
+    var result = sanitize(string);
+    t.equal(result, '<span style="font-size: 10.5pt ; color: black"></span>');
+    t.end();
+});

--- a/test/css.js
+++ b/test/css.js
@@ -52,3 +52,10 @@ test('Should sanitize doubly escaped nonsense values', function(t) {
     t.equal(result, '<span style="font-size: 10.5pt ; color: black"></span>');
     t.end();
 });
+
+test('Should keep valid function in styles', function(t) {
+   var string = '<span style="background-color: rgb(0 , 12 , 12)"></span>';
+   var result = sanitize(string);
+    t.equal(result, string);
+    t.end();
+});


### PR DESCRIPTION
Running into an issue with an escaped string causing a catastrophic
backtrack with the regex to determine the CSS_TOKEN. The offending string
is matched by the WORD_TERM portion of the regex though, so by moving it ahead
of FUNCTION in the join, we can ensure we perform the quicker match before
hitting the catastrophy